### PR TITLE
Popup marker

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -23,6 +23,9 @@ export default class extends Controller {
     this.markersValue.forEach((marker) => {
       const customMarker = document.createElement("div")
       customMarker.style.backgroundSize = "contain"
+      // customMarker.setAttribute("id", `${this.rightTarget.id}${'%d: %s', i}`)
+      // can't get the following to show edit
+      customMarker.setAttribute("data-action", `click->challenge#showModal`)
       customMarker.classList.add("unfound-marker");
 
       // Pass the element as an argument to the new marker


### PR DESCRIPTION
added ability to click on a marker and get a pop up; no huge progress with this one but will leave it in/merge it in case it's useful for the player side question pop ups

if you click markers on game overview you'll be shown make a new challenge; wanted to be able to edit instead though and wasn't able to. 